### PR TITLE
Add csk asset host support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v2.1.0
+
+- Add csk_asset_host to customize the asset_host extension for the csk's
+filename rewriting behavior and supported file types
+
 # v2.0.0
 
 - Restructured as a Thor Template so that meta files like the README and

--- a/template/config.rb
+++ b/template/config.rb
@@ -28,7 +28,9 @@
     # activate :minify_css
     # activate :minify_javascript
     if ENV['CSK_ASSET_HOST']
-      activate :asset_host, host: ENV['CSK_ASSET_HOST']
+      require 'csk_asset_host'
+      ::Middleman::Extensions.register(:csk_asset_host, CskAssetHost)
+      activate :csk_asset_host, host: ENV['CSK_ASSET_HOST']
     else
       activate :relative_assets
     end

--- a/template/csk_asset_host.rb
+++ b/template/csk_asset_host.rb
@@ -10,11 +10,13 @@ class CskAssetHost < ::Middleman::Extension
   option :rewrite_ignore, [], 'Regexes of filenames to skip processing for host rewrites'
   option :asset_path_rewriter, nil, 'Proc for modifying the asset path'
 
+  CSK_ASSET_EXTENSIONS = %w'.mp3 .pdf .docx .xlsx'
+
   def initialize(app, options_hash={}, &block)
     super
 
     app.rewrite_inline_urls id: :asset_host,
-                            url_extensions: options.exts || app.config[:asset_extensions],
+                            url_extensions: (options.exts || app.config[:asset_extensions]) + CSK_ASSET_EXTENSIONS,
                             source_extensions: options.sources,
                             ignore: options.ignore,
                             rewrite_ignore: options.rewrite_ignore,

--- a/template/csk_asset_host.rb
+++ b/template/csk_asset_host.rb
@@ -1,12 +1,14 @@
+# fork of core AssetHost extension
 # https://github.com/middleman/middleman/blob/v4.3.10/middleman-core/lib/middleman-core/extensions/asset_host.rb
 require 'addressable/uri'
 
-class Middleman::Extensions::AssetHost < ::Middleman::Extension
+class CskAssetHost < ::Middleman::Extension
   option :host, nil, 'The asset host to use or a Proc to determine asset host', required: true
   option :exts, nil, 'List of extensions that get cache busters strings appended to them.'
   option :sources, %w(.css .htm .html .js .php .xhtml), 'List of extensions that are searched for bustable assets.'
   option :ignore, [], 'Regexes of filenames to skip adding query strings to'
   option :rewrite_ignore, [], 'Regexes of filenames to skip processing for host rewrites'
+  option :asset_path_rewriter, nil, 'Proc for modifying the asset path'
 
   def initialize(app, options_hash={}, &block)
     super
@@ -30,6 +32,8 @@ class Middleman::Extensions::AssetHost < ::Middleman::Extension
       asset_path
     end
 
+    full_asset_path = sanitize_full_asset_path(full_asset_path)
+
     asset_prefix = if options[:host].is_a?(Proc)
       options[:host].call(full_asset_path)
     elsif options[:host].is_a?(String)
@@ -39,4 +43,15 @@ class Middleman::Extensions::AssetHost < ::Middleman::Extension
     File.join(asset_prefix, full_asset_path)
   end
   memoize :rewrite_url
+
+  private
+  def sanitize_full_asset_path full_asset_path
+    parts = full_asset_path.split('/')
+    path_prefix = parts[0...-1]
+    filename = parts[-1]
+    # Duplicate the sanitization done by the asset host (replace non-word characters with `_`)
+    sanitized_filename = filename.gsub(/[^.\w]/, '_')
+
+    (path_prefix + [sanitized_filename]).join('/')
+  end
 end

--- a/template/csk_asset_host.rb
+++ b/template/csk_asset_host.rb
@@ -1,0 +1,42 @@
+# https://github.com/middleman/middleman/blob/v4.3.10/middleman-core/lib/middleman-core/extensions/asset_host.rb
+require 'addressable/uri'
+
+class Middleman::Extensions::AssetHost < ::Middleman::Extension
+  option :host, nil, 'The asset host to use or a Proc to determine asset host', required: true
+  option :exts, nil, 'List of extensions that get cache busters strings appended to them.'
+  option :sources, %w(.css .htm .html .js .php .xhtml), 'List of extensions that are searched for bustable assets.'
+  option :ignore, [], 'Regexes of filenames to skip adding query strings to'
+  option :rewrite_ignore, [], 'Regexes of filenames to skip processing for host rewrites'
+
+  def initialize(app, options_hash={}, &block)
+    super
+
+    app.rewrite_inline_urls id: :asset_host,
+                            url_extensions: options.exts || app.config[:asset_extensions],
+                            source_extensions: options.sources,
+                            ignore: options.ignore,
+                            rewrite_ignore: options.rewrite_ignore,
+                            proc: method(:rewrite_url)
+  end
+
+  Contract String, Or[String, Pathname], Any => String
+  def rewrite_url(asset_path, dirpath, _request_path)
+    uri = ::Middleman::Util.parse_uri(asset_path)
+    relative_path = uri.path[0..0] != '/'
+
+    full_asset_path = if relative_path
+      dirpath.join(asset_path).to_s
+    else
+      asset_path
+    end
+
+    asset_prefix = if options[:host].is_a?(Proc)
+      options[:host].call(full_asset_path)
+    elsif options[:host].is_a?(String)
+      options[:host]
+    end
+
+    File.join(asset_prefix, full_asset_path)
+  end
+  memoize :rewrite_url
+end


### PR DESCRIPTION
This fixes a bug where referencing static assets may not work because the filename can change when uploaded to the chorus_asset_service.