### PR TITLE
Add amp link tag to <head> in template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v2.2.0
+
+- Add conditional rendering of AMP url to <head> in layout.erb
+
 # v2.1.0
 
 - Add csk_asset_host to customize the asset_host extension for the csk's

--- a/template/source/layouts/layout.erb
+++ b/template/source/layouts/layout.erb
@@ -48,6 +48,10 @@
 
     <%= partial('layouts/newsarticleschema') %>
 
+    <% if data.content.entry.ampUrl %>
+        <link rel="amphtml" href="<%= data.content.entry.ampUrl %>"/>
+    <% end %>
+
     <%# Favicons %>
     <link rel="icon" type="image/png" href="<%= data.content.community.favicon32 %>" sizes="32x32">
     <link rel="icon" type="image/png" href="<%= data.content.community.favicon192 %>" sizes="192x192">


### PR DESCRIPTION
This PR adds an AMP link tag to the `<head>` in `layout.erb`. 

This PR should be deployed after https://vmproduct.atlassian.net/browse/TOOLS-650's work, so that we don't end up in a situation where the `Disable AMP` toggle results in this link tag still being rendered.

This PR depends on, and can be deployed before or after, https://github.com/voxmedia/csk-cli/pull/111.

Ticket: [Add amp_url and google amp link to base middleman template](https://vmproduct.atlassian.net/browse/TOOLS-651)